### PR TITLE
Add further details on Google API keys to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,12 @@ const wmsOpts = {
 const wmsLayer = myMap.addLayer('wms', wmsOpts);
 
 // Adding a Google Map Tiles layer. This requires registering a Google Developer
-// account and creating your own private API key. The one below is a fake key
-// that won't work but will look similar to your key. Be sure never to share
-// yours and if it is accidentally exposed or committed, create a new one. See:
-// https://developers.google.com/maps/documentation/javascript/get-api-key
+// account and creating your own Map Tiles API key. See the following
+// documentation on creating and restricting API keys.
+// "Google strongly recommends that you restrict your API keys by limiting their
+// usage to those only APIs needed for your application. Restricting API keys
+// adds security to your application by protecting it from unwarranted requests."
+// https://developers.google.com/maps/documentation/tile/get-api-key
 const googleMapOpts = {
   title: 'Google Satellite',
   key: 'AIzaSyAs-AoPi0VEcL7feKFQRkNpAdjznxqFi3k', // replace with your API key.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ const wmsLayer = myMap.addLayer('wms', wmsOpts);
 // https://developers.google.com/maps/documentation/tile/get-api-key
 const googleMapOpts = {
   title: 'Google Satellite',
-  key: 'AIzaSyAs-AoPi0VEcL7feKFQRkNpAdjznxqFi3k', // replace with your API key.
+  key: 'AIzaSyBEB1xUvz8LG_XexTVKv5ghXEPaCzF9eng', // replace with your API key.
   mapType: 'satellite',
   visible: true, // defaults to true
   base: true, // defaults to false

--- a/README.md
+++ b/README.md
@@ -185,10 +185,14 @@ const wmsOpts = {
 };
 const wmsLayer = myMap.addLayer('wms', wmsOpts);
 
-// Adding a Google Map Tiles layer.
+// Adding a Google Map Tiles layer. This requires registering a Google Developer
+// account and creating your own private API key. The one below is a fake key
+// that won't work but will look similar to your key. Be sure never to share
+// yours and if it is accidentally exposed or committed, create a new one. See:
+// https://developers.google.com/maps/documentation/javascript/get-api-key
 const googleMapOpts = {
   title: 'Google Satellite',
-  key: 'private-api-key',
+  key: 'AIzaSyAs-AoPi0VEcL7feKFQRkNpAdjznxqFi3k', // replace with your API key.
   mapType: 'satellite',
   visible: true, // defaults to true
   base: true, // defaults to false


### PR DESCRIPTION
Note that the example API key is the one displayed in the official Google tutorial video, the same one linked in the documentation: https://www.youtube.com/watch?v=2_HZObVbe-g&t=72s